### PR TITLE
Remove Spot instance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is a game server stack built using the AWS Cloud Development Kit (C
 ## Features
 
 - Single VPC & Public subnet
-- EC2 spot instance for hosting dedicated game servers
+- EC2 instance for hosting dedicated game servers
 - Hourly AMI backup with Data Lifecycle Manager policy
 - Automanic SteamCMD setup
 - Infrastructure-as-Code using the AWS CDK for easy deployment and management
@@ -31,7 +31,7 @@ Before getting started, make sure you have the following:
 1. Deploy the stack: `cdk deploy`
 1. Monitor the deployment progress in the AWS CloudFormation console
 
-By default your EC2 instance will be created via the spot intance request just for cost optimization. If it makes you umcomfortable, pls remove `spotOptions` from the LanchTemplate within the `lib/game-server-stack.ts`
+EC2 instances are launched as On-Demand instances.
 
 ## Contributing
 

--- a/bin/game-server.ts
+++ b/bin/game-server.ts
@@ -17,7 +17,6 @@ const GAMES = {
     instanceType: InstanceType.of(InstanceClass.T3A, InstanceSize.LARGE),
     ports: [Port.udp(8211)],
     volumeSize: Size.gibibytes(32),
-    useSpot: true,
     execCommand: () => "/data/game/PalServer.sh",
   },
   Satisfactory: {
@@ -28,7 +27,6 @@ const GAMES = {
     ),
     ports: [Port.tcp(7777), Port.udp(7777), Port.udp(15000), Port.udp(15777)],
     volumeSize: Size.gibibytes(24),
-    useSpot: true,
     volumeId: "vol-0713378dc970fb43d",
     /** Savedata is created under user's home */
     mountPaths: ["/home/ec2-user/.config/Epic"],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,18 +1,13 @@
 import { Size, Stack, StackProps, Tag } from "aws-cdk-lib";
 import { CfnLifecyclePolicy } from "aws-cdk-lib/aws-dlm";
 import {
-  CfnEIP,
-  CfnEIPAssociation,
   EbsDeviceVolumeType,
   Instance,
   InstanceType,
-  LaunchTemplate,
   MachineImage,
   Peer,
   Port,
   SecurityGroup,
-  SpotInstanceInterruption,
-  SpotRequestType,
   SubnetType,
   UserData,
   Volume,
@@ -39,11 +34,6 @@ interface GameServerCommonProps extends StackProps {
    * @example InstanceType.of(InstanceClass.T3A, InstanceSize.LARGE)
    */
   instanceType: InstanceType;
-  /**
-   * By specifying true, use spot instances
-   * @default false
-   */
-  useSpot?: boolean;
   /**
    * The volume size of the persistent volume
    * Note that this doesn't apply for the root volume
@@ -104,15 +94,6 @@ export class GameServerStack extends Stack {
       securityGroup.addIngressRule(Peer.anyIpv4(), port)
     );
 
-    const launchTemplate = new LaunchTemplate(this, "Template", {
-      spotOptions: props.useSpot
-        ? {
-            requestType: SpotRequestType.PERSISTENT,
-            interruptionBehavior: SpotInstanceInterruption.STOP,
-          }
-        : undefined,
-    });
-
     const userData = UserData.forLinux();
     const mountPaths = ["/data", ...(props.mountPaths ?? [])];
     userData.addCommands(
@@ -154,18 +135,9 @@ export class GameServerStack extends Stack {
       "systemctl start game"
     );
 
-    const { instance: cfnInstance, instanceId } = instance;
+    const { instance: cfnInstance } = instance;
     const { volumeId } = this.getVolume(props.volumeId);
     cfnInstance.volumes = [{ device: DEVICE_NAME, volumeId }];
-    cfnInstance.launchTemplate = {
-      version: launchTemplate.versionNumber,
-      launchTemplateId: launchTemplate.launchTemplateId,
-    };
-    if (props.useSpot)
-      new CfnEIPAssociation(this, "EIPAssociation", {
-        allocationId: new CfnEIP(this, "EIP").attrAllocationId,
-        instanceId,
-      });
 
     const executionRoleArn = Role.fromRoleName(
       this,

--- a/test/aws-cdk-example.test.ts
+++ b/test/aws-cdk-example.test.ts
@@ -23,7 +23,6 @@ test("VPC and EC2 instance created", () => {
   template.resourceCountIs("AWS::EC2::Subnet", 1);
   template.resourceCountIs("AWS::EC2::RouteTable", 1);
   template.resourceCountIs("AWS::EC2::Instance", 1);
-  template.resourceCountIs("AWS::EC2::LaunchTemplate", 1);
   template.resourceCountIs("AWS::EC2::SecurityGroup", 1);
   template.resourceCountIs("AWS::EC2::Volume", 1);
   template.resourceCountIs("AWS::EC2::InternetGateway", 1);


### PR DESCRIPTION
## Summary

- remove the Spot instance configuration API and launch template
- remove Spot-specific Elastic IP resources
- update the examples, README, and infrastructure test for On-Demand instances

## Why

Spot interruptions can leave the game server unavailable. The stack now launches On-Demand EC2 instances only.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`
- `npx cdk synth` (confirmed no Spot, EIP, or launch-template resources)